### PR TITLE
fix(rule): dedupe `Math.sumPrecise` reports (`no-math-sum-precise`)

### DIFF
--- a/src/rules/no-bigint64array/__tests__/rule.spec.ts
+++ b/src/rules/no-bigint64array/__tests__/rule.spec.ts
@@ -25,14 +25,29 @@ describe("no-bigint64array", () => {
     expect(msgs.length).toBeGreaterThan(0);
   });
 
+  it("does not duplicate on BigInt64Array constructor", async () => {
+    const msgs = await run("new BigInt64Array(8)");
+    expect(msgs.length).toBe(1);
+  });
+
   it("flags BigUint64Array constructor usage", async () => {
     const msgs = await run("new BigUint64Array(8)");
     expect(msgs.length).toBeGreaterThan(0);
   });
 
+  it("does not duplicate on BigUint64Array constructor", async () => {
+    const msgs = await run("new BigUint64Array(8)");
+    expect(msgs.length).toBe(1);
+  });
+
   it("flags static member access on BigInt64Array", async () => {
     const msgs = await run("const n = BigInt64Array.BYTES_PER_ELEMENT");
     expect(msgs.length).toBeGreaterThan(0);
+  });
+
+  it("does not duplicate on BigInt64Array member access", async () => {
+    const msgs = await run("const n = BigInt64Array.BYTES_PER_ELEMENT");
+    expect(msgs.length).toBe(1);
   });
 
   it("does not flag unrelated typed arrays", async () => {

--- a/src/rules/no-function-caller-arguments/__tests__/rule.spec.ts
+++ b/src/rules/no-function-caller-arguments/__tests__/rule.spec.ts
@@ -34,4 +34,14 @@ describe("no-function-caller-arguments", () => {
     const msgs = await run("const o={}; o.color; o.args;");
     expect(msgs.length).toBe(0);
   });
+
+  it("does not duplicate on single .caller", async () => {
+    const msgs = await run("function f(){}; f.caller;");
+    expect(msgs.length).toBe(1);
+  });
+
+  it("does not duplicate on single .arguments", async () => {
+    const msgs = await run("function f(){}; f.arguments;");
+    expect(msgs.length).toBe(1);
+  });
 });

--- a/src/rules/no-math-sum-precise/__tests__/rule.spec.ts
+++ b/src/rules/no-math-sum-precise/__tests__/rule.spec.ts
@@ -20,9 +20,9 @@ async function run(code: string) {
 // - spec: https://tc39.es/proposal-math-sum/
 
 describe("no-math-sum-precise", () => {
-  it("flags Math.sumPrecise() calls", async () => {
+  it("flags Math.sumPrecise() calls (no duplicates)", async () => {
     const msgs = await run("Math.sumPrecise(1,2)");
-    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs.length).toBe(1);
   });
 
   it("flags member access to sumPrecise", async () => {

--- a/src/rules/no-math-sum-precise/index.ts
+++ b/src/rules/no-math-sum-precise/index.ts
@@ -33,7 +33,10 @@ const rule: Rule.RuleModule = {
         }
       },
       MemberExpression(node: unknown) {
-        const m = node as Record<string, unknown>;
+        const m = node as Record<string, unknown> & { parent?: unknown };
+        // Avoid duplicate reports when this MemberExpression is the callee of a CallExpression
+        const parent = m.parent as { type?: string; callee?: unknown } | undefined;
+        if (parent?.type === "CallExpression" && parent.callee === node) return;
         if (
           m.computed === false &&
           (m.object as Record<string, unknown>)?.type === "Identifier" &&

--- a/src/rules/no-temporal/__tests__/rule.spec.ts
+++ b/src/rules/no-temporal/__tests__/rule.spec.ts
@@ -25,9 +25,19 @@ describe("no-temporal", () => {
     expect(msgs.length).toBeGreaterThan(0);
   });
 
+  it("does not duplicate on Temporal.Now.instant()", async () => {
+    const msgs = await run("Temporal.Now.instant()");
+    expect(msgs.length).toBe(1);
+  });
+
   it("flags new Temporal.PlainDate()", async () => {
     const msgs = await run("new Temporal.PlainDate(2020,1,1)");
     expect(msgs.length).toBeGreaterThan(0);
+  });
+
+  it("does not duplicate on new Temporal.PlainDate()", async () => {
+    const msgs = await run("new Temporal.PlainDate(2020,1,1)");
+    expect(msgs.length).toBe(1);
   });
 
   it("does not flag unrelated identifiers", async () => {

--- a/tests/esx.spec.ts
+++ b/tests/esx.spec.ts
@@ -328,6 +328,15 @@ describe("orchestrator (es-x delegates)", () => {
     ).toBe(true);
   });
 
+  it("[math-sum-precise] should not produce duplicate reports", async () => {
+    const code = "Math.sumPrecise(1,2)";
+    const msgs = await lintWithBaseline(code, "widely");
+    const count = msgs.filter((m) =>
+      m.includes("Feature 'math-sum-precise' is not a widely available Baseline feature."),
+    ).length;
+    expect(count).toBe(1);
+  });
+
   it("[temporal] (limited) should be flagged on widely", async () => {
     const code = "Temporal.Now.instant()";
     const msgs = await lintWithBaseline(code, "widely");


### PR DESCRIPTION
fix 
- #14