### PR TITLE
chore: support custom filePattern

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface CommonRuleOptions {
   baseline?: BaselineOption;
   available?: BaselineOption; // alias (optional)
   env?: EnvOption;
+  filePattern?: RegExp; // file name pattern to match, default: /\.(?:[mc]?[jt]s|[jt]sx)$/i
   tsAware?: boolean;
   failOn?: "limited" | "newly" | "all";
   // Ignore options (rule-specific). Strings beginning and ending with '/' are treated as regex.

--- a/src/orchestrator/use-baseline.ts
+++ b/src/orchestrator/use-baseline.ts
@@ -65,6 +65,7 @@ const rule: Rule.RuleModule = {
             anyOf: [{ enum: ["widely", "newly"] }, { type: "number" }],
             default: "widely",
           },
+          filePattern: { type: "object", instanceof: "RegExp" },
           ignoreFeatures: { type: "array", items: { type: "string" } },
           ignoreNodeTypes: { type: "array", items: { type: "string" } },
           includeWebApis: {
@@ -114,12 +115,12 @@ const rule: Rule.RuleModule = {
       const value = getFilename.call(ctx as unknown as object);
       if (typeof value === "string" && !value.startsWith("<")) filename = value;
     }
+    const opt = (ctx.options[0] ?? {}) as CommonRuleOptions;
     if (filename) {
       // Accept common JS/TS extensions
-      const isJsLike = /\.(?:[mc]?[jt]s|[jt]sx)$/i.test(filename);
+      const isJsLike = (opt.filePattern ?? /\.(?:[mc]?[jt]s|[jt]sx)$/i).test(filename);
       if (!isJsLike) return {};
     }
-    const opt = (ctx.options[0] ?? {}) as CommonRuleOptions;
     const baseline = getBaselineValue(opt);
     const ignoreFeaturePatterns = (opt.ignoreFeatures ?? []) as string[];
     const ignoreNodeTypePatterns = (opt.ignoreNodeTypes ?? []) as string[];


### PR DESCRIPTION
When applied to files other than `.(t|j)s` such as `.vue`, syntax validation cannot currently be achieved due to limitations in below code. 
```javascript
if (filename) {
  const isJsLike = /\.(?:[mc]?[jt]s|[jt]sx)$/i.test(filename);
  if (!isJsLike) return {};
}
```

Therefore, a configurable file suffix option is provided to customize the file scope.
```javascript
if (filename) {
  const isJsLike = (opt.filePattern ?? /\.(?:[mc]?[jt]s|[jt]sx)$/i).test(filename);
  if (!isJsLike) return {};
}
```
