### PR TITLE
Remove extension gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "tsdown": "0.15.12",
     "typescript": "^5.9.3",
     "vitest": "^4.0.5",
+    "vue-eslint-parser": "^9.4.3",
     "web-features": "3.6.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       vitest:
         specifier: ^4.0.5
         version: 4.0.5(@types/node@24.9.2)(jiti@2.6.1)
+      vue-eslint-parser:
+        specifier: ^9.4.3
+        version: 9.4.3(eslint@9.37.0(jiti@2.6.1))
       web-features:
         specifier: 3.6.0
         version: 3.6.0
@@ -1103,6 +1106,10 @@ packages:
     peerDependencies:
       eslint: '>=9.29.0'
 
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1134,6 +1141,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
@@ -2293,6 +2304,12 @@ packages:
       jsdom:
         optional: true
 
+  vue-eslint-parser@9.4.3:
+    resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
   web-features@3.6.0:
     resolution: {integrity: sha512-XuxKJvAvdTXDw3U3jcabcWNOFmQHWhTa69O0+crQDjpe5s0Odc4NNASImW1n77Gye7leBzKchVswGfO86ZbNPA==}
 
@@ -3305,6 +3322,11 @@ snapshots:
       eslint: 9.37.0(jiti@2.6.1)
       eslint-type-tracer: 0.4.1(eslint@9.37.0(jiti@2.6.1))
 
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -3366,6 +3388,12 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 3.4.3
 
   esquery@1.6.0:
     dependencies:
@@ -4393,6 +4421,19 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vue-eslint-parser@9.4.3(eslint@9.37.0(jiti@2.6.1)):
+    dependencies:
+      debug: 4.4.3
+      eslint: 9.37.0(jiti@2.6.1)
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      lodash: 4.17.21
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   web-features@3.6.0: {}
 

--- a/tests/use-baseline-extensions.spec.ts
+++ b/tests/use-baseline-extensions.spec.ts
@@ -1,0 +1,77 @@
+import type { Rule } from "eslint";
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+import vueParser from "vue-eslint-parser";
+import plugin from "../dist/index.mjs";
+
+const rule = (plugin as unknown as { rules: Record<string, Rule.RuleModule> }).rules[
+  "use-baseline"
+] as Rule.RuleModule;
+
+const vueTester = new RuleTester({
+  languageOptions: {
+    parser: vueParser,
+    parserOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+    },
+  },
+});
+
+const reactTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+describe("use-baseline across common frontend hosts", () => {
+  it("lints Vue SFCs when the project supplies vue-eslint-parser", () => {
+    vueTester.run("baseline-js/use-baseline (vue sfc)", rule, {
+      valid: [
+        {
+          filename: "Component.vue",
+          code: `<template><div>{{ foo ?? "fallback" }}</div></template>
+<script setup>
+const value = foo ?? "fallback";
+</script>`,
+          options: [{ available: "widely" }],
+        },
+      ],
+      invalid: [
+        {
+          filename: "Component.vue",
+          code: `<template><div>{{ foo }}</div></template>
+<script setup>
+const t = Temporal.Now.instant();
+</script>`,
+          options: [{ available: "widely" }],
+          errors: [{ message: /temporal/i }],
+        },
+      ],
+    });
+  });
+
+  it("lints React-style JSX files", () => {
+    reactTester.run("baseline-js/use-baseline (react jsx)", rule, {
+      valid: [
+        {
+          filename: "Component.jsx",
+          code: "const App = () => <div>{foo ?? 'ok'}</div>;",
+          options: [{ available: "widely" }],
+        },
+      ],
+      invalid: [
+        {
+          filename: "Component.jsx",
+          code: "const App = () => <div>{Temporal.Now.instant()}</div>;",
+          options: [{ available: "widely" }],
+          errors: [{ message: /temporal/i }],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Closes #56 by addressing the feature request without adding a filePattern option. Instead of hard-coding extensions, we now rely on ESLint’s files/parser selection and simply skip when the parser doesn’t produce a JS Program AST. This keeps the plugin predictable across hosts (JS/TS/Vue/JSX) and avoids per-rule file scope duplication. 