### PR TITLE
docs: add html-eslint react

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,14 @@ and shows which ones are currently mapped by this plugin.
 | `ignoreFeatures`       | `string[]`                | —          | Skip specific web‑features by ID (supports regex `/.../`) across syntax delegates and Web API/JS builtin detection. |
 | `ignoreNodeTypes`      | `string[]`                | —          | Suppress reports by ESTree `node.type` (supports regex `/.../`). |
 
-## Baseline for HTML and CSS
+## Baseline for HTML, CSS, and React
 
-Baseline works best when HTML, CSS, and JS all align. For markup and styles, enable the "use-baseline" rules from these ESLint plugins:
+Baseline works best when HTML, CSS, JS, and React all align. For markup, styles, and React, enable the "use-baseline" rules from these ESLint plugins:
 
 - ESLint for CSS: https://github.com/eslint/css
-- HTML ESLint: https://github.com/yeonjuan/html-eslint
+- HTML ESLint (HTML): https://github.com/yeonjuan/html-eslint
+- HTML ESLint (React): https://github.com/yeonjuan/html-eslint/tree/main/packages/eslint-plugin-react
+
 
 ## Branding Note (Baseline)
 


### PR DESCRIPTION
Hi!
I am currently working on adding support for React, Vue, and other frameworks to some rules in html-eslint.
The React plugin has just been released, and it now includes the use-baseline rule for JSX. I would like to update the documentation accordingly.
Thank you.
- https://html-eslint.org/docs/react/rules/use-baseline
- [playground](https://html-eslint.org/playground#eyJjb2RlIjoiY29uc3QgQ29tcG9uZW50ID0gKCkgPT4ge1xuICAgIHJldHVybiA8PlxuICAgICAgPGEgcmVsPVwibm8gcmVmZXJyZVwiPmxpbms8L2E+XG4gICAgICA8aW5wdXQgdHlwZT1cIndlZWtcIi8+XG4gICAgPC8+O1xufSIsImNvbmZpZyI6eyJydWxlcyI6eyJAaHRtbC1lc2xpbnQvcmVhY3QvdXNlLWJhc2VsaW5lIjoiZXJyb3IiLCJAaHRtbC1lc2xpbnQvcmVhY3Qvbm8taW52YWxpZC1hdHRyLXZhbHVlIjoiZXJyb3IifX0sImxhbmd1YWdlIjoianN4In0=)