### PR TITLE
chore(ci): test against minimum supported ESLint versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
     needs: [format]
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        eslint-version: ['8.57.0', '9.0.0']
+    name: test (eslint@${{ matrix.eslint-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,6 +62,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
+
+      - name: Override ESLint version
+        run: pnpm add -D eslint@${{ matrix.eslint-version }} --no-lockfile
       
       - name: Generate features (web-features -> features.ts)
         run: pnpm gen:features
@@ -65,6 +73,7 @@ jobs:
         run: pnpm build
 
       - name: Type check
+        if: matrix.eslint-version == '9.0.0'
         run: pnpm typecheck
 
       - name: Run tests

--- a/src/rules/no-atomics-pause/__tests__/rule.spec.ts
+++ b/src/rules/no-atomics-pause/__tests__/rule.spec.ts
@@ -1,9 +1,10 @@
 import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { ESLintCompat } from "../../../../tests/compat";
 import plugin from "../../../index";
 
 async function run(code: string) {
-  const eslint = new ESLint({
+  const eslint = new ESLintCompat({
     overrideConfigFile: true,
     overrideConfig: {
       languageOptions: { ecmaVersion: 2022, sourceType: "module" },

--- a/src/rules/no-bigint64array/__tests__/rule.spec.ts
+++ b/src/rules/no-bigint64array/__tests__/rule.spec.ts
@@ -1,9 +1,10 @@
 import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { ESLintCompat } from "../../../../tests/compat";
 import plugin from "../../../index";
 
 async function run(code: string) {
-  const eslint = new ESLint({
+  const eslint = new ESLintCompat({
     overrideConfigFile: true,
     overrideConfig: {
       languageOptions: { ecmaVersion: 2022, sourceType: "module" },

--- a/src/rules/no-function-caller-arguments/__tests__/rule.spec.ts
+++ b/src/rules/no-function-caller-arguments/__tests__/rule.spec.ts
@@ -1,9 +1,10 @@
 import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { ESLintCompat } from "../../../../tests/compat";
 import plugin from "../../../index";
 
 async function run(code: string) {
-  const eslint = new ESLint({
+  const eslint = new ESLintCompat({
     overrideConfigFile: true,
     overrideConfig: {
       languageOptions: { ecmaVersion: 2022, sourceType: "module" },

--- a/src/rules/no-math-sum-precise/__tests__/rule.spec.ts
+++ b/src/rules/no-math-sum-precise/__tests__/rule.spec.ts
@@ -1,9 +1,10 @@
 import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { ESLintCompat } from "../../../../tests/compat";
 import plugin from "../../../index";
 
 async function run(code: string) {
-  const eslint = new ESLint({
+  const eslint = new ESLintCompat({
     overrideConfigFile: true,
     overrideConfig: {
       languageOptions: { ecmaVersion: 2022, sourceType: "module" },

--- a/src/rules/no-temporal/__tests__/rule.spec.ts
+++ b/src/rules/no-temporal/__tests__/rule.spec.ts
@@ -1,9 +1,10 @@
 import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { ESLintCompat } from "../../../../tests/compat";
 import plugin from "../../../index";
 
 async function run(code: string) {
-  const eslint = new ESLint({
+  const eslint = new ESLintCompat({
     overrideConfigFile: true,
     overrideConfig: {
       languageOptions: { ecmaVersion: 2022, sourceType: "module" },

--- a/tests/compat.ts
+++ b/tests/compat.ts
@@ -1,0 +1,30 @@
+/**
+ * ESLint version compatibility layer for tests.
+ *
+ * ESLint v9+ ships a flat-config-native `RuleTester` and `ESLint` class.
+ * ESLint v8 uses legacy config by default, but exposes flat-config variants
+ * as `FlatRuleTester` and `FlatESLint` from `eslint/use-at-your-own-risk`.
+ *
+ * This module re-exports the correct class so tests work across v8, v9+,
+ * without any config format changes.
+ */
+
+import { ESLint as DefaultESLint, RuleTester as DefaultRuleTester } from "eslint";
+import eslintPkg from "eslint/package.json";
+
+const major = Number(eslintPkg.version.split(".")[0]);
+
+let _RuleTester = DefaultRuleTester;
+let _ESLint = DefaultESLint;
+
+if (major < 9) {
+  const unstable = (await import("eslint/use-at-your-own-risk")) as unknown as {
+    FlatRuleTester: typeof DefaultRuleTester;
+    FlatESLint: typeof DefaultESLint;
+  };
+  _RuleTester = unstable.FlatRuleTester;
+  _ESLint = unstable.FlatESLint;
+}
+
+export const RuleTester = _RuleTester;
+export const ESLintCompat = _ESLint;

--- a/tests/global-functions.spec.ts
+++ b/tests/global-functions.spec.ts
@@ -1,7 +1,7 @@
 import type { Rule } from "eslint";
-import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 import plugin from "../dist/index.mjs";
+import { RuleTester } from "./compat";
 
 /**
  * Tests for global function detection (callGlobal descriptor).

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,6 @@
 import { ESLint } from "eslint";
 import plugin from "../src";
+import { ESLintCompat } from "./compat";
 
 export async function lintWithBaseline(
   code: string,
@@ -7,7 +8,7 @@ export async function lintWithBaseline(
   opts: { filePath?: string; sourceType?: "script" | "module" } = {},
   ruleOptions: Record<string, unknown> = {},
 ) {
-  const eslint = new ESLint({
+  const eslint = new ESLintCompat({
     overrideConfigFile: true,
     overrideConfig: {
       languageOptions: {

--- a/tests/jsbi-safe.spec.ts
+++ b/tests/jsbi-safe.spec.ts
@@ -1,7 +1,7 @@
 import type { Rule } from "eslint";
-import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 import plugin from "../dist/index.mjs";
+import { RuleTester } from "./compat";
 
 const rule = (plugin as unknown as { rules: Record<string, Rule.RuleModule> }).rules[
   "use-baseline"

--- a/tests/messages.e2e.spec.ts
+++ b/tests/messages.e2e.spec.ts
@@ -1,7 +1,7 @@
 import type { Rule } from "eslint";
-import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 import plugin from "../dist/index.mjs";
+import { RuleTester } from "./compat";
 
 const rule = (plugin as unknown as { rules: Record<string, Rule.RuleModule> }).rules[
   "use-baseline"

--- a/tests/typed-builtins.spec.ts
+++ b/tests/typed-builtins.spec.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { ESLintCompat } from "./compat";
 
 async function ensureTsParser(): Promise<unknown | null> {
   try {
@@ -86,7 +86,7 @@ describe("typed builtins detection (Intl.Locale, Iterator, Uint8Array instance)"
     const flatConfigPath = join(tmp, "eslint.config.mjs");
     await fs.writeFile(flatConfigPath, "export default [{}]\n", "utf8");
 
-    const eslint = new ESLint({
+    const eslint = new ESLintCompat({
       cwd: tmp,
       overrideConfigFile: flatConfigPath,
       overrideConfig: [
@@ -152,7 +152,7 @@ describe("typed builtins detection (Intl.Locale, Iterator, Uint8Array instance)"
     await fs.writeFile(flatConfigPath, "export default [{}]\n", "utf8");
 
     // Typed-aware run → should report
-    const eslintTyped = new ESLint({
+    const eslintTyped = new ESLintCompat({
       cwd: tmp,
       overrideConfigFile: flatConfigPath,
       overrideConfig: [
@@ -179,7 +179,7 @@ describe("typed builtins detection (Intl.Locale, Iterator, Uint8Array instance)"
     expect(msgsTyped.some((m) => /Resizable buffers/.test(m.message))).toBe(true);
 
     // Non-typed (safe preset) run → should not report due to typedOnly gating
-    const eslintUntyped = new ESLint({
+    const eslintUntyped = new ESLintCompat({
       cwd: tmp,
       overrideConfigFile: flatConfigPath,
       overrideConfig: [

--- a/tests/typed-mode.test.ts
+++ b/tests/typed-mode.test.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { ESLintCompat } from "./compat";
 
 describe("typed mode (TypeScript-aware) integration", () => {
   it("reports instance member APIs when baseline excludes them", async () => {
@@ -63,7 +63,7 @@ describe("typed mode (TypeScript-aware) integration", () => {
     const flatConfigPath = join(tmpRoot, "eslint.config.mjs");
     await fs.writeFile(flatConfigPath, "export default [{}]\n", "utf8");
 
-    const eslint = new ESLint({
+    const eslint = new ESLintCompat({
       cwd: tmpRoot,
       overrideConfigFile: flatConfigPath,
       overrideConfig: [
@@ -146,7 +146,7 @@ describe("typed mode (TypeScript-aware) integration", () => {
     const flatConfigPath = join(tmpRoot, "eslint.config.mjs");
     await fs.writeFile(flatConfigPath, "export default [{}]\n", "utf8");
 
-    const eslint = new ESLint({
+    const eslint = new ESLintCompat({
       cwd: tmpRoot,
       overrideConfigFile: flatConfigPath,
       overrideConfig: [

--- a/tests/use-baseline-extensions.spec.ts
+++ b/tests/use-baseline-extensions.spec.ts
@@ -1,8 +1,8 @@
 import type { Rule } from "eslint";
-import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 import vueParser from "vue-eslint-parser";
 import plugin from "../dist/index.mjs";
+import { RuleTester } from "./compat";
 
 const rule = (plugin as unknown as { rules: Record<string, Rule.RuleModule> }).rules[
   "use-baseline"

--- a/tests/use-baseline.e2e.spec.ts
+++ b/tests/use-baseline.e2e.spec.ts
@@ -5,9 +5,9 @@
  */
 
 import type { Rule } from "eslint";
-import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 import plugin from "../dist/index.mjs";
+import { RuleTester } from "./compat";
 
 const rule = (plugin as unknown as { rules: Record<string, Rule.RuleModule> }).rules[
   "use-baseline"

--- a/tests/utils/ruleRunner.ts
+++ b/tests/utils/ruleRunner.ts
@@ -1,6 +1,6 @@
 import type { Rule } from "eslint";
-import { RuleTester } from "eslint";
 import plugin from "../../dist/index.mjs";
+import { RuleTester } from "../compat";
 
 export function makeRuleTester(opts?: { ecmaVersion?: number; sourceType?: "script" | "module" }) {
   return new RuleTester({

--- a/tests/webapi-safe.spec.ts
+++ b/tests/webapi-safe.spec.ts
@@ -1,7 +1,7 @@
 import type { Rule } from "eslint";
-import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 import plugin from "../dist/index.mjs";
+import { RuleTester } from "./compat";
 
 const rule = (plugin as unknown as { rules: Record<string, Rule.RuleModule> }).rules[
   "use-baseline"


### PR DESCRIPTION
Adds a CI matrix to test against the minimum supported version of each ESLint major (`8.57.0` and `9.0.0`), matching the `>=8.57.0 <10` peer dependency. A compat module detects the ESLint version and re-exports the flat-config `RuleTester`/`ESLint` classes so all tests work unchanged across both majors.
