### PR TITLE
refactor: use `context.sourceCode` instead of deprecated APIs

### DIFF
--- a/src/orchestrator/use-baseline.ts
+++ b/src/orchestrator/use-baseline.ts
@@ -108,10 +108,8 @@ const rule: Rule.RuleModule = {
   },
   create(ctx) {
     const _DEBUG = process.env.BASELINE_DEBUG === "1";
-    const sourceCode = ctx.getSourceCode?.();
-    const ast = sourceCode?.ast as { type?: string } | undefined;
     // Avoid running when the parser did not produce a JS Program (eg, non-ESTree processors)
-    if (ast && ast.type && ast.type !== "Program") return {};
+    if (ctx.sourceCode.ast.type !== "Program") return {};
     const opt = (ctx.options[0] ?? {}) as CommonRuleOptions;
     const baseline = getBaselineValue(opt);
     const ignoreFeaturePatterns = (opt.ignoreFeatures ?? []) as string[];
@@ -185,7 +183,6 @@ const rule: Rule.RuleModule = {
       const delegateCtx: Record<string, unknown> = {};
       // Forward commonly used context methods/properties safely
       const fwd = [
-        "getSourceCode",
         "getCwd",
         "getFilename",
         "getPhysicalFilename",
@@ -271,14 +268,8 @@ const rule: Rule.RuleModule = {
       }
       return "off";
     }
-    type ParserServicesLike = { program?: unknown; esTreeNodeToTSNodeMap?: unknown };
-    type CtxLike = {
-      parserServices?: ParserServicesLike;
-      sourceCode?: { parserServices?: ParserServicesLike };
-    };
-    const cx = ctx as unknown as CtxLike;
-    const ps = cx.parserServices || cx.sourceCode?.parserServices;
-    const typedAvailable = !!ps?.program && !!ps?.esTreeNodeToTSNodeMap;
+    const ps = ctx.sourceCode.parserServices as Record<string, unknown>;
+    const typedAvailable = "program" in ps && "esTreeNodeToTSNodeMap" in ps;
     const useTypesWeb = resolveUseTypes(includeWebApis);
     const useTypesJs = resolveUseTypes(includeJsBuiltins);
     const wantTyped =
@@ -300,7 +291,6 @@ const rule: Rule.RuleModule = {
       // Build a delegate context similar to other delegates
       const delegateCtx: Record<string, unknown> = {};
       const fwd = [
-        "getSourceCode",
         "getCwd",
         "getFilename",
         "getPhysicalFilename",
@@ -327,14 +317,6 @@ const rule: Rule.RuleModule = {
       ]) {
         const src = ctx as unknown as Record<string, unknown>;
         if (src[k] != null) delegateCtx[k] = src[k];
-      }
-      if (
-        delegateCtx.sourceCode == null &&
-        typeof (ctx as unknown as { getSourceCode?: () => unknown }).getSourceCode === "function"
-      ) {
-        delegateCtx.sourceCode = (
-          ctx as unknown as { getSourceCode: () => unknown }
-        ).getSourceCode();
       }
       delegateCtx.options = [
         typedEnabled ? { descriptors, messages, typed: true } : { descriptors, messages },

--- a/src/rules/feature-usage/builder.ts
+++ b/src/rules/feature-usage/builder.ts
@@ -35,19 +35,8 @@ export function buildListeners(context: Rule.RuleContext, opt: BuildOptions): Ru
     context.report({ node: node as unknown as Rule.Node, message: msg });
   }
 
-  type ParserServicesLike = {
-    program?: { getTypeChecker?: () => unknown };
-    esTreeNodeToTSNodeMap?: unknown;
-  };
-  type CtxLike = {
-    parserServices?: ParserServicesLike;
-    sourceCode?: { parserServices?: ParserServicesLike };
-  };
-  const ctxLike = context as unknown as CtxLike;
-  const services: ParserServicesLike =
-    ctxLike.parserServices || ctxLike.sourceCode?.parserServices || {};
-  const checker: unknown = services.program?.getTypeChecker?.();
-  const useTyped = !!opt.typed && !!checker && !!services.esTreeNodeToTSNodeMap;
+  const services = context.sourceCode.parserServices as Record<string, unknown>;
+  const useTyped = !!opt.typed && "program" in services && "esTreeNodeToTSNodeMap" in services;
 
   for (const d of opt.descriptors) {
     switch (d.kind) {

--- a/src/rules/feature-usage/detectors/typed-instance-member.ts
+++ b/src/rules/feature-usage/detectors/typed-instance-member.ts
@@ -15,18 +15,9 @@ export function addTypedInstanceMemberDetector(
     getPropertyOfType?: (t: unknown, name: string) => unknown;
     getApparentType?: (t: unknown) => unknown;
   };
-  type ParserServicesLike = {
-    program?: { getTypeChecker?: () => TsCheckerLike };
-    esTreeNodeToTSNodeMap?: { get(n: unknown): unknown };
-  };
-  type CtxLike = {
-    parserServices?: ParserServicesLike;
-    sourceCode?: { parserServices?: ParserServicesLike };
-  };
-  const ctxLike = context as unknown as CtxLike;
-  const services: ParserServicesLike =
-    ctxLike.parserServices || ctxLike.sourceCode?.parserServices || {};
-  const checker: TsCheckerLike | undefined = services.program?.getTypeChecker?.();
+  const services = context.sourceCode.parserServices as Record<string, unknown>;
+  const program = services.program as { getTypeChecker?: () => TsCheckerLike } | undefined;
+  const checker = program?.getTypeChecker?.();
   if (!checker || !services.esTreeNodeToTSNodeMap) return {};
   const checkerOk = checker; // non-null assertion helper for narrowing
   const tsMap = services.esTreeNodeToTSNodeMap; // non-null assertion helper

--- a/src/rules/feature-usage/index.ts
+++ b/src/rules/feature-usage/index.ts
@@ -28,11 +28,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     const opt = (context.options?.[0] ?? {}) as Options;
-    const descs = (opt.descriptors ?? []) as ReadonlyArray<Descriptor>;
-    const messages = (opt.messages ?? {}) as Record<string, string>;
     const useTyped = !!opt.typed;
-    // ESLint v9 exposes parserServices under sourceCode
-    return buildListeners(context, { descriptors: descs, messages, typed: useTyped });
+    return buildListeners(context, {
+      descriptors: opt.descriptors,
+      messages: opt.messages,
+      typed: useTyped,
+    });
   },
 };
 

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -1,21 +1,15 @@
-import type { Rule } from "eslint";
+import type { Rule, Scope } from "eslint";
 
-// In ESLint v9, context.getScope() is not available.
-// Instead, use sourceCode.scopeManager to resolve the scope for a node.
 export function isUnboundIdentifier(
   context: Rule.RuleContext,
   name: string,
   refNode?: unknown,
 ): boolean {
-  const sc = (context as unknown as { sourceCode?: { scopeManager?: unknown } }).sourceCode
-    ?.scopeManager as { acquire?: (n: unknown) => unknown; globalScope?: unknown } | undefined;
-  if (!sc) return true; // Be conservative: treat as unbound when scope info is missing
-  // Acquire a scope from refNode when provided; otherwise walk from globalScope.
-  let scope: unknown = (refNode && sc.acquire?.(refNode)) || sc.globalScope || null;
+  const sc = context.sourceCode.scopeManager;
+  let scope = refNode ? sc.acquire(refNode as Rule.Node) : sc.globalScope;
   while (scope) {
-    const s = scope as { set?: { has?: (k: string) => boolean }; upper?: unknown };
-    if (s.set?.has?.(name)) return false;
-    scope = s.upper || null;
+    if (scope.set.has(name)) return false;
+    scope = scope.upper;
   }
   return true;
 }
@@ -34,54 +28,17 @@ export function isGlobalNotShadowed(
   name: string,
   parentNode: unknown,
 ): boolean {
-  // These loose types mirror eslint-scope shapes without depending on private types.
-  type VariableLike = {
-    name?: string;
-    defs?: unknown[];
-    eslintExplicitGlobal?: boolean;
-  };
-  type ScopeLike = {
-    set?: { has?: (k: string) => boolean; get?: (k: string) => unknown };
-    variables?: VariableLike[];
-    upper?: unknown;
-    type?: string;
-  };
-
-  function findVariable(
-    scope: ScopeLike,
-    varName: string,
-  ): {
-    found: boolean;
-    variable?: VariableLike;
-  } {
-    // Some scope containers fill only one of these; checking all reduces false positives.
-    const bySet = scope.set?.get?.(varName) as VariableLike | undefined;
-    if (bySet) return { found: true, variable: bySet };
-    if (Array.isArray(scope.variables)) {
-      const byVars = scope.variables.find((v) => v?.name === varName);
-      if (byVars) return { found: true, variable: byVars };
-    }
-    if (scope.set?.has?.(varName)) return { found: true };
-    return { found: false };
-  }
-
-  const sourceCode = context.sourceCode as { getScope?: (n: unknown) => unknown };
-  if (!sourceCode?.getScope) return true; // Conservative: avoid false positives when scope info is missing
-  const scope = sourceCode.getScope(parentNode);
-
-  let current: unknown = scope;
-  while (current) {
-    const s = current as ScopeLike;
-    const { found, variable } = findVariable(s, name);
-    if (found) {
-      if (s.type !== "global") return false; // Shadowed by local declaration
+  let scope: Scope.Scope | null = context.sourceCode.getScope(parentNode as Rule.Node);
+  while (scope) {
+    const variable = scope.set.get(name);
+    if (variable) {
+      if (scope.type !== "global") return false; // Shadowed by local declaration
       // In script files, top-level `var`/`function` live in global scope.
       // Only treat them as shadowing when ESLint marks them with defs; built-ins have none.
-      const defs = variable?.defs;
-      if (Array.isArray(defs) && defs.length > 0) return false;
+      if (variable.defs.length > 0) return false;
       return true;
     }
-    current = s.upper || null;
+    scope = scope.upper;
   }
   return true;
 }


### PR DESCRIPTION
Replaces usage of deprecated ESLint `RuleContext` APIs related to `sourceCode` access with their modern equivalents. The plugin's minimum supported ESLint version is **8.57.0** (`peerDependencies: ">=8.57.0 <10"`), so all replacement APIs are guaranteed to be available.

### Changes

#### `RuleContext.getSourceCode()` → `context.sourceCode`

Replaced with `context.sourceCode` (available since v8.40.0, [#17107](https://github.com/eslint/eslint/pull/17107)). Removed forwarding of `getSourceCode` to delegate rule contexts and the associated fallback block.

#### `context.parserServices` → `context.sourceCode.parserServices`

Replaced with `context.sourceCode.parserServices` (available since v8.44.0, [#17311](https://github.com/eslint/eslint/pull/17311)). `SourceCode.parserServices` always defaults to `{}`, so the `| undefined` cast and double-fallback pattern (`cx.parserServices || cx.sourceCode?.parserServices`) are no longer needed. The `ParserServicesLike` / `CtxLike` helper types that existed to support the fallback have been removed.

#### `context.getScope()` → `context.sourceCode.getScope()` / `context.sourceCode.scopeManager`

Replaced with `context.sourceCode.getScope(node)` (available since v8.37.0, [#17004](https://github.com/eslint/eslint/pull/17004)) and `context.sourceCode.scopeManager`. Removed defensive null guards and optional chaining around scope APIs. Replaced loose inline type aliases (`ScopeLike`, `VariableLike`) with the proper `Scope.Scope` / `Scope.Variable` types from `eslint`, and eliminated the `findVariable` helper whose triple-fallback (`set.get`, `variables.find`, `set.has`) was redundant (`scope.set` is always a `Map` built from `scope.variables`).