### PR TITLE
feat: add ESLint 10 support, drop ESLint 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,20 @@ jobs:
     needs: [format]
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        eslint-version: ['9.29.0', '10']
+    name: test (eslint@${{ matrix.eslint-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-          
+
       - name: Install pnpm
         run: |
           corepack enable
           corepack prepare pnpm@10.15.1 --activate
-        
+
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
@@ -57,7 +62,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
-      
+
+      - name: Override ESLint version
+        if: matrix.eslint-version != '10'
+        run: pnpm add -D eslint@${{ matrix.eslint-version }} --no-lockfile
+
       - name: Generate features (web-features -> features.ts)
         run: pnpm gen:features
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/eslint": "^9.6.1",
     "@types/node": "^25.0.3",
     "@typescript-eslint/parser": "^8.51.0",
-    "eslint": "^9.39.2",
+    "eslint": "^10.0.2",
     "semantic-release": "^25.0.2",
     "tsdown": "0.18.4",
     "typescript": "^5.9.3",
@@ -58,7 +58,7 @@
     "web-features": "3.14.0"
   },
   "peerDependencies": {
-    "eslint": ">=8.57.0 <10"
+    "eslint": ">=9.29.0 <11"
   },
   "packageManager": "pnpm@10.15.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       eslint-plugin-es-x:
         specifier: ^9.5.0
-        version: 9.5.0(eslint@9.39.2(jiti@2.6.1))
+        version: 9.5.0(eslint@10.0.2(jiti@2.6.1))
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.10
@@ -29,10 +29,10 @@ importers:
         version: 25.1.0
       '@typescript-eslint/parser':
         specifier: ^8.51.0
-        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.54.0(eslint@10.0.2(jiti@2.6.1))(typescript@5.9.3)
       eslint:
-        specifier: ^9.39.2
-        version: 9.39.2(jiti@2.6.1)
+        specifier: ^10.0.2
+        version: 10.0.2(jiti@2.6.1)
       semantic-release:
         specifier: ^25.0.2
         version: 25.0.3(typescript@5.9.3)
@@ -47,7 +47,7 @@ importers:
         version: 4.0.18(@types/node@25.1.0)(jiti@2.6.1)
       vue-eslint-parser:
         specifier: ^10.2.0
-        version: 10.2.0(eslint@9.39.2(jiti@2.6.1))
+        version: 10.2.0(eslint@10.0.2(jiti@2.6.1))
       web-features:
         specifier: 3.14.0
         version: 3.14.0
@@ -329,33 +329,25 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/config-array@0.23.2':
+    resolution: {integrity: sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/config-helpers@0.5.2':
+    resolution: {integrity: sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/core@1.1.0':
+    resolution: {integrity: sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/eslintrc@3.3.1':
-    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/object-schema@3.0.2':
+    resolution: {integrity: sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/js@9.39.2':
-    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/plugin-kit@0.6.0':
+    resolution: {integrity: sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -804,6 +796,9 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -892,6 +887,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -904,8 +904,8 @@ packages:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-escapes@7.1.1:
     resolution: {integrity: sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==}
@@ -958,6 +958,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -967,11 +971,12 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1044,9 +1049,6 @@ packages:
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -1194,6 +1196,10 @@ packages:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-scope@9.1.1:
+    resolution: {integrity: sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint-type-tracer@0.4.1:
     resolution: {integrity: sha512-7kDovYNNitAxahP/qQ9UrHssUk8d6V5Y9MQaDiHPKsJrk1g6STDqVHjJPu8ycn1+qE4D0jwQRN7waRrxrX9k+Q==}
     engines: {node: ^18 || >=20}
@@ -1208,9 +1214,13 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.39.2:
-    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.0.2:
+    resolution: {integrity: sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1222,8 +1232,16 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  espree@11.1.1:
+    resolution: {integrity: sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -1366,10 +1384,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -1601,9 +1615,6 @@ packages:
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
-  lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
   lodash.uniqby@4.7.0:
     resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
 
@@ -1655,8 +1666,9 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -2136,10 +2148,6 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
-
-  strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
 
   super-regex@1.0.0:
     resolution: {integrity: sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==}
@@ -2655,55 +2663,39 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@10.0.2(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 10.0.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.2(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 10.0.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.23.2':
     dependencies:
-      '@eslint/object-schema': 2.1.7
+      '@eslint/object-schema': 3.0.2
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.4.2':
+  '@eslint/config-helpers@0.5.2':
     dependencies:
-      '@eslint/core': 0.17.0
+      '@eslint/core': 1.1.0
 
-  '@eslint/core@0.17.0':
+  '@eslint/core@1.1.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/object-schema@3.0.2': {}
+
+  '@eslint/plugin-kit@0.6.0':
     dependencies:
-      ajv: 6.12.6
-      debug: 4.4.3
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/js@9.39.2': {}
-
-  '@eslint/object-schema@2.1.7': {}
-
-  '@eslint/plugin-kit@0.4.1':
-    dependencies:
-      '@eslint/core': 0.17.0
+      '@eslint/core': 1.1.0
       levn: 0.4.1
 
   '@humanfs/core@0.19.1': {}
@@ -3098,6 +3090,8 @@ snapshots:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3108,14 +3102,14 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.54.0(eslint@10.0.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 10.0.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3203,7 +3197,13 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.15.0: {}
+
+  acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
 
@@ -3217,7 +3217,7 @@ snapshots:
       clean-stack: 5.3.0
       indent-string: 5.0.0
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -3261,20 +3261,21 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   before-after-hook@4.0.0: {}
 
   birpc@4.0.0: {}
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -3350,8 +3351,6 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
-
-  concat-map@0.0.1: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -3482,50 +3481,56 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-es-x@9.5.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-es-x@9.5.0(eslint@10.0.2(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-type-tracer: 0.4.1(eslint@9.39.2(jiti@2.6.1))
+      eslint: 10.0.2(jiti@2.6.1)
+      eslint-type-tracer: 0.4.1(eslint@10.0.2(jiti@2.6.1))
 
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-type-tracer@0.4.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-scope@9.1.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
-      eslint: 9.39.2(jiti@2.6.1)
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.8
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-type-tracer@0.4.1(eslint@10.0.2(jiti@2.6.1)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@10.0.2(jiti@2.6.1))
+      eslint: 10.0.2(jiti@2.6.1)
 
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.0.2(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@10.0.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.39.2
-      '@eslint/plugin-kit': 0.4.1
+      '@eslint/config-array': 0.23.2
+      '@eslint/config-helpers': 0.5.2
+      '@eslint/core': 1.1.0
+      '@eslint/plugin-kit': 0.6.0
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
-      chalk: 4.1.2
+      ajv: 6.14.0
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
+      eslint-scope: 9.1.1
+      eslint-visitor-keys: 5.0.1
+      espree: 11.1.1
+      esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 8.0.0
@@ -3535,8 +3540,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.4
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -3550,7 +3554,17 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
+  espree@11.1.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
   esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -3705,8 +3719,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  globals@14.0.0: {}
 
   graceful-fs@4.2.10: {}
 
@@ -3896,8 +3908,6 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
-  lodash.merge@4.6.2: {}
-
   lodash.uniqby@4.7.0: {}
 
   lodash@4.17.21: {}
@@ -3938,9 +3948,9 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  minimatch@3.1.2:
+  minimatch@10.2.4:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 5.0.4
 
   minimatch@9.0.5:
     dependencies:
@@ -4398,8 +4408,6 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
-  strip-json-comments@3.1.1: {}
-
   super-regex@1.0.0:
     dependencies:
       function-timeout: 1.0.2
@@ -4612,10 +4620,10 @@ snapshots:
       - tsx
       - yaml
 
-  vue-eslint-parser@10.2.0(eslint@9.39.2(jiti@2.6.1)):
+  vue-eslint-parser@10.2.0(eslint@10.0.2(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 10.0.2(jiti@2.6.1)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0

--- a/src/orchestrator/use-baseline.ts
+++ b/src/orchestrator/use-baseline.ts
@@ -19,6 +19,31 @@ import { mergeRuleListeners } from "../utils/listeners";
 
 type ListenerMap = Rule.RuleListener;
 
+function buildDelegateContext(
+  ctx: Rule.RuleContext,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const src = ctx as unknown as Record<string, unknown>;
+  const delegateCtx: Record<string, unknown> = {};
+
+  // Forward properties that delegates actually consume
+  if (src.sourceCode != null) delegateCtx.sourceCode = src.sourceCode;
+  if (src.settings != null) delegateCtx.settings = src.settings;
+
+  // parserServices may live on ctx directly or on sourceCode (ESLint 10)
+  type CtxWithPS = { parserServices?: unknown; sourceCode?: { parserServices?: unknown } };
+  const cx = ctx as unknown as CtxWithPS;
+  const ps = cx.parserServices ?? cx.sourceCode?.parserServices;
+  if (ps != null) delegateCtx.parserServices = ps;
+
+  // Apply caller overrides (options, report, parserOptions, etc.)
+  for (const [k, v] of Object.entries(overrides)) {
+    delegateCtx[k] = v;
+  }
+
+  return delegateCtx;
+}
+
 // Register project-local rules once so they can be resolved via the 'self' plugin.
 const SELF_RULES: Record<string, Rule.RuleModule> = {
   "no-atomics-pause": noAtomicsPause,
@@ -108,10 +133,10 @@ const rule: Rule.RuleModule = {
   },
   create(ctx) {
     const _DEBUG = process.env.BASELINE_DEBUG === "1";
-    const sourceCode = ctx.getSourceCode?.();
-    const ast = sourceCode?.ast as { type?: string } | undefined;
+    const sourceCode = ctx.sourceCode;
+    const ast = sourceCode.ast as { type?: string } | undefined;
     // Avoid running when the parser did not produce a JS Program (eg, non-ESTree processors)
-    if (ast && ast.type && ast.type !== "Program") return {};
+    if (ast?.type && ast.type !== "Program") return {};
     const opt = (ctx.options[0] ?? {}) as CommonRuleOptions;
     const baseline = getBaselineValue(opt);
     const ignoreFeaturePatterns = (opt.ignoreFeatures ?? []) as string[];
@@ -181,64 +206,40 @@ const rule: Rule.RuleModule = {
       const impl = resolveDelegateRule(plugin, name);
       if (!impl?.create) continue;
 
-      // Create a minimal context wrapper that forwards necessary APIs and overrides report/options.
-      const delegateCtx: Record<string, unknown> = {};
-      // Forward commonly used context methods/properties safely
-      const fwd = [
-        "getSourceCode",
-        "getCwd",
-        "getFilename",
-        "getPhysicalFilename",
-        "getAncestors",
-        "getDeclaredVariables",
-        "markVariableAsUsed",
-        "getScope",
-      ] as const;
-      for (const k of fwd) {
-        const v = (ctx as unknown as Record<string, unknown>)[k as string];
-        if (typeof v === "function") {
-          type AnyFn = (...args: unknown[]) => unknown;
-          const fn = v as unknown as AnyFn;
-          delegateCtx[k] = fn.bind(ctx);
-        }
-      }
-      // Pass-through common data containers if present
-      for (const k of [
-        "settings",
-        "parserPath",
-        "parserServices",
-        "languageOptions",
-        "sourceCode",
-      ]) {
-        const src = ctx as unknown as Record<string, unknown>;
-        if (src[k] != null) delegateCtx[k] = src[k];
-      }
       // Force es-x delegates to consider syntax as "unsupported" by lowering ecmaVersion.
-      {
-        const src = ctx as unknown as { parserOptions?: Record<string, unknown> };
-        const orig = src.parserOptions ?? {};
-        (delegateCtx as Record<string, unknown>).parserOptions = { ...orig, ecmaVersion: 3 };
-      }
-      // Provide options expected by the delegate rule
-      delegateCtx.options = delegateOptions;
-      // Unified Baseline-aware reporting
-      delegateCtx.report = function report(arg: unknown) {
-        const isObj = typeof arg === "object" && arg !== null;
-        const node =
-          isObj && "node" in (arg as Record<string, unknown>)
-            ? (arg as Record<string, unknown>).node
-            : arg;
-        if (matchIgnoreNodeType) {
-          const t = (node as Record<string, unknown> | null | undefined)?.type as
-            | string
-            | undefined;
-          if (t && matchIgnoreNodeType(t)) return;
-        }
-        (ctx as unknown as { report: (d: { node: unknown; message: string }) => void }).report({
-          node,
-          message: baselineMessage(featureId, baseline),
-        });
-      };
+      const origParserOptions =
+        (ctx as unknown as { parserOptions?: Record<string, unknown> }).parserOptions ?? {};
+      const origLangOpts =
+        (ctx as unknown as { languageOptions?: Record<string, unknown> }).languageOptions ?? {};
+      const delegateCtx = buildDelegateContext(ctx, {
+        parserOptions: { ...origParserOptions, ecmaVersion: 3 },
+        languageOptions: {
+          ...origLangOpts,
+          ecmaVersion: 3,
+          parserOptions: {
+            ...((origLangOpts.parserOptions as Record<string, unknown> | undefined) ?? {}),
+            ecmaVersion: 3,
+          },
+        },
+        options: delegateOptions,
+        report(arg: unknown) {
+          const isObj = typeof arg === "object" && arg !== null;
+          const node =
+            isObj && "node" in (arg as Record<string, unknown>)
+              ? (arg as Record<string, unknown>).node
+              : arg;
+          if (matchIgnoreNodeType) {
+            const t = (node as Record<string, unknown> | null | undefined)?.type as
+              | string
+              | undefined;
+            if (t && matchIgnoreNodeType(t)) return;
+          }
+          (ctx as unknown as { report: (d: { node: unknown; message: string }) => void }).report({
+            node,
+            message: baselineMessage(featureId, baseline),
+          });
+        },
+      });
 
       const l = impl.create(delegateCtx as unknown as Rule.RuleContext);
       mergeRuleListeners(listeners, l);
@@ -297,73 +298,32 @@ const rule: Rule.RuleModule = {
     if (descriptors.length > 0) {
       const messages: Record<string, string> = {};
       for (const d of descriptors) messages[d.featureId] = baselineMessage(d.featureId, baseline);
-      // Build a delegate context similar to other delegates
-      const delegateCtx: Record<string, unknown> = {};
-      const fwd = [
-        "getSourceCode",
-        "getCwd",
-        "getFilename",
-        "getPhysicalFilename",
-        "getAncestors",
-        "getDeclaredVariables",
-        "markVariableAsUsed",
-        "getScope",
-      ] as const;
-      for (const k of fwd) {
-        const v = (ctx as unknown as Record<string, unknown>)[k as string];
-        if (typeof v === "function") {
-          type AnyFn = (...args: unknown[]) => unknown;
-          const fn = v as unknown as AnyFn;
-          delegateCtx[k] = fn.bind(ctx);
-        }
-      }
-      for (const k of [
-        "settings",
-        "parserPath",
-        "parserOptions",
-        "parserServices",
-        "languageOptions",
-        "sourceCode",
-      ]) {
-        const src = ctx as unknown as Record<string, unknown>;
-        if (src[k] != null) delegateCtx[k] = src[k];
-      }
-      if (
-        delegateCtx.sourceCode == null &&
-        typeof (ctx as unknown as { getSourceCode?: () => unknown }).getSourceCode === "function"
-      ) {
-        delegateCtx.sourceCode = (
-          ctx as unknown as { getSourceCode: () => unknown }
-        ).getSourceCode();
-      }
-      delegateCtx.options = [
-        typedEnabled ? { descriptors, messages, typed: true } : { descriptors, messages },
-      ];
-      // Ensure report is available to the generic detector (feature-usage)
-      // so it can forward to the primary rule context and respect ignoreNodeTypes.
-      (delegateCtx as unknown as { report: (arg: unknown) => void }).report = function report(
-        arg: unknown,
-      ) {
-        const isObj = typeof arg === "object" && arg !== null;
-        const node =
-          isObj && "node" in (arg as Record<string, unknown>)
-            ? (arg as Record<string, unknown>).node
-            : arg;
-        if (matchIgnoreNodeType) {
-          const t = (node as Record<string, unknown> | null | undefined)?.type as
-            | string
-            | undefined;
-          if (t && matchIgnoreNodeType(t)) return;
-        }
-        let msg: string | undefined;
-        if (isObj && typeof (arg as { message?: unknown }).message === "string")
-          msg = (arg as { message?: string }).message;
+      const delegateCtx = buildDelegateContext(ctx, {
+        options: [
+          typedEnabled ? { descriptors, messages, typed: true } : { descriptors, messages },
+        ],
+        report(arg: unknown) {
+          const isObj = typeof arg === "object" && arg !== null;
+          const node =
+            isObj && "node" in (arg as Record<string, unknown>)
+              ? (arg as Record<string, unknown>).node
+              : arg;
+          if (matchIgnoreNodeType) {
+            const t = (node as Record<string, unknown> | null | undefined)?.type as
+              | string
+              | undefined;
+            if (t && matchIgnoreNodeType(t)) return;
+          }
+          let msg: string | undefined;
+          if (isObj && typeof (arg as { message?: unknown }).message === "string")
+            msg = (arg as { message?: string }).message;
 
-        (ctx as unknown as { report: (d: { node: unknown; message?: string }) => void }).report({
-          node,
-          message: msg,
-        });
-      };
+          (ctx as unknown as { report: (d: { node: unknown; message?: string }) => void }).report({
+            node,
+            message: msg,
+          });
+        },
+      });
       const generic = featureUsage.create(delegateCtx as unknown as Rule.RuleContext);
       mergeRuleListeners(listeners, generic);
     }


### PR DESCRIPTION
## Summary

- Widen `peerDependencies` to `>=9.29.0 <11`, aligning with eslint-plugin-es-x ≥9.5 which already requires `>=9.29.0`
- Replace removed ESLint 10 APIs (`ctx.getSourceCode()` → `ctx.sourceCode`)
- Extract `buildDelegateContext()` helper, forwarding only the properties delegates actually consume (`sourceCode`, `settings`, `parserServices`)
- Remove all deprecated method forwarding and backward-compat shims (verified unused against es-x 9.5.0 source)
- Add CI matrix testing against ESLint 9.29.0 (min supported) and 10

## Breaking changes

- ESLint 8 is no longer supported. Minimum is now ESLint 9.29.0.

### rel
- #84 
- #87
- #89 
- #90 