### PR TITLE
feat: drop CJS build, publish ESM-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,19 +5,15 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    }
+    ".": "./dist/index.mjs",
+    "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "files": [
-    "dist/index.cjs",
     "dist/index.mjs",
-    "dist/index.d.mts",
-    "dist/index.d.cts"
+    "dist/index.d.mts"
   ],
   "scripts": {
     "build": "tsdown",
@@ -62,7 +58,7 @@
   },
   "packageManager": "pnpm@10.15.1",
   "engines": {
-    "node": ">=20.19.0 <22 || >=22.12.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "author": {
     "name": "Ryuya",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: false,
-  format: ["esm", "cjs"],
+  format: ["esm"],
   target: "es2020",
   fixedExtension: true,
   inputOptions(defaults) {


### PR DESCRIPTION

Closes #70. Supersedes #71.

Drop the CJS build and publish ESM-only. All supported Node.js versions (`^20.19.0 || >=22.12.0`) ship with unflagged `require(esm)`, so CJS consumers can load this package transparently via `require()`.

### Changes

- Remove `exports.require` and CJS entry from `package.json`
- Remove `.cjs` / `.d.cts` from `files`
- Change tsdown `format` from `["esm", "cjs"]` to `["esm"]`
- Simplify `engines.node` to `^20.19.0 || >=22.12.0`

### Why

- Eliminates the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard)
- Removes interop complexity between CJS/ESM declaration files
- Halves the distributed package size
- See: [Anthony Fu — Move on to ESM-only](https://antfu.me/posts/move-on-to-esm-only#the-troubles-with-dual-formats)

### Breaking changes

- CJS `require()` still works via Node.js `require(esm)`, but requires Node.js `^20.19.0 || >=22.12.0` (already enforced by `engines`)