### PR TITLE
Add oxlint JS plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,30 @@ and shows which ones are currently mapped by this plugin.
 | `ignoreFeatures`       | `string[]`                | —          | Skip specific web‑features by ID (supports regex `/.../`) across syntax delegates and Web API/JS builtin detection. |
 | `ignoreNodeTypes`      | `string[]`                | —          | Suppress reports by ESTree `node.type` (supports regex `/.../`). |
 
+## Use with [oxlint](https://oxc.rs/)
+
+Runs as an [oxlint JS plugin](https://oxc.rs/docs/guide/usage/linter/js-plugins). Just drop it into `.oxlintrc.json`:
+
+```jsonc
+// .oxlintrc.json
+{
+  "jsPlugins": ["eslint-plugin-baseline-js"],
+  "rules": {
+    "baseline-js/use-baseline": [
+      "warn",
+      {
+        "available": "widely",
+        "includeWebApis": { "preset": "auto" },
+        "includeJsBuiltins": { "preset": "auto" }
+      }
+    ]
+  }
+}
+```
+
+> [!CAUTION]
+> **No type-aware detection under oxlint.** Checks that need TypeScript type resolution (e.g., `Set.difference()`, `Iterator.map()`) won't fire. Use ESLint with the `type-aware` preset if you need them.
+
 ## Baseline for HTML, CSS, and React
 
 Baseline works best when HTML, CSS, JS, and React all align. For markup, styles, and React, enable the "use-baseline" rules from these ESLint plugins:

--- a/docs/website/content/docs/config.mdx
+++ b/docs/website/content/docs/config.mdx
@@ -135,8 +135,9 @@ Both control “what surface to detect and how aggressive it should be”. The t
     }
     ```
 
-- `preset: 'type-aware'` (strictest)
+- `preset: ‘type-aware’` (strictest)
   - Requires TS types. Resolves the receiver’s actual type before reporting instance members
+  - **Not available under oxlint.** Instance-member checks won't fire. See [FAQ](/docs/meta/faq#using-with-oxlinthttpoxcrs--less-precise-detection).
   - Example:
     ```ts title="type-aware preset (TS project)"
     import tsParser from '@typescript-eslint/parser';
@@ -335,6 +336,30 @@ module.exports = {
   </div>
 </details>
 
+
+## Use with [oxlint](https://oxc.rs/)
+
+Drop the plugin into your [`.oxlintrc.json`](https://oxc.rs/docs/guide/usage/linter/js-plugins):
+
+```jsonc title=".oxlintrc.json"
+{
+  "jsPlugins": ["eslint-plugin-baseline-js"],
+  "rules": {
+    "baseline-js/use-baseline": [
+      "warn",
+      {
+        "available": "widely",
+        "includeWebApis": { "preset": "auto" },
+        "includeJsBuiltins": { "preset": "auto" }
+      }
+    ]
+  }
+}
+```
+
+<Callout type="error" title="No type-aware detection under oxlint">
+Checks that need TypeScript type resolution (e.g., `Set.difference()`, `Iterator.map()`) won't fire. Use ESLint with the `type-aware` preset if you need them. See [FAQ](/docs/meta/faq#using-with-oxlinthttpoxcrs--less-precise-detection).
+</Callout>
 
 ### Messages
 

--- a/docs/website/content/docs/examples.mdx
+++ b/docs/website/content/docs/examples.mdx
@@ -228,3 +228,23 @@ module.exports = {
 <Callout type="info" title="Tip: constants">
 Prefer <code>BASELINE.WIDELY/NEWLY</code> over string literals to avoid typos.
 </Callout>
+
+## [oxlint](https://oxc.rs/)
+
+```jsonc title=".oxlintrc.json"
+// Drop-in oxlint support. Type-aware detection won't work here;
+// use 'safe' or 'auto' instead of 'type-aware'.
+{
+  "jsPlugins": ["eslint-plugin-baseline-js"],
+  "rules": {
+    "baseline-js/use-baseline": [
+      "warn",
+      {
+        "available": "widely",
+        "includeWebApis": { "preset": "auto" },
+        "includeJsBuiltins": { "preset": "auto" }
+      }
+    ]
+  }
+}
+```

--- a/docs/website/content/docs/meta/faq.mdx
+++ b/docs/website/content/docs/meta/faq.mdx
@@ -32,6 +32,12 @@ export default [
 
 </details>
 
+## Using with [oxlint](https://oxc.rs/): less precise detection
+
+[oxlint JS plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins) don't have access to TypeScript type information. Checks that rely on type resolution (`Set.difference()`, `Iterator.map()`, `response.arrayBuffer()`, etc.) won't fire. Everything else (syntax, constructors, static methods, globals) works fine.
+
+If you need full instance-member coverage, run ESLint with the `type-aware` preset.
+
 ## False positives / suppression
 
 Try the following first, then open an issue with a repro sample if needed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import type { Rule } from "eslint";
 import { baselineConfigs, recommendedConfig, recommendedTsConfig } from "./configs/baseline";
 
@@ -10,6 +11,11 @@ import noFunctionCallerArguments from "./rules/no-function-caller-arguments";
 import noMathSumPrecise from "./rules/no-math-sum-precise";
 import noTemporal from "./rules/no-temporal";
 
+const pkg = createRequire(import.meta.url)("../package.json") as {
+  name: string;
+  version: string;
+};
+
 const rules: Record<string, Rule.RuleModule> = {
   "use-baseline": useBaseline,
   "no-atomics-pause": noAtomicsPause,
@@ -20,6 +26,10 @@ const rules: Record<string, Rule.RuleModule> = {
 };
 
 export default {
+  meta: {
+    name: pkg.name,
+    version: pkg.version,
+  },
   rules,
   configs: {
     baseline: baselineConfigs,


### PR DESCRIPTION
## Summary

- Add `meta.name` / `meta.version` to plugin export (required by oxlint's JS plugin loader)
- Document oxlint usage and type-aware detection limitation


> [!CAUTION]
> **No type-aware detection under oxlint.** Checks that require TypeScript type resolution will be skipped. For comprehensive coverage and precise detection, I strongly recommend continuing to use ESLint with the `type-aware` preset.